### PR TITLE
Fix typo and enhance version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,9 @@
   "keywords": ["process", "background task", "nohup", "pid"],
   "license": "MIT",
   "type": "library",
+  "require": {
+    "php": "^7.2"
+  },
   "require-dev": {
     "phpunit/phpunit": "~7.0",
     "orchestra/testbench": "~3.4.0|~3.5.0|~3.6.0"

--- a/src/Operation.php
+++ b/src/Operation.php
@@ -56,7 +56,7 @@ class Operation
     /**
      * Execute the process.
      *
-     * @param \Closure $closure The anonyouse function to execute.
+     * @param \Closure $closure The anonymous function to execute.
      *
      * @return void
      */
@@ -125,7 +125,7 @@ class Operation
         $handle = proc_open(
             $cmd,
             $desc,
-            $pipes,
+            [],
             getcwd()
         );
 

--- a/src/Utils/FunctionReflection.php
+++ b/src/Utils/FunctionReflection.php
@@ -10,7 +10,7 @@ class FunctionReflection
     /**
      * Get the string representation of the anonymous function.
      *
-     * @param Closre $closure The anonymous function.
+     * @param \Closure $closure The anonymous function.
      *
      * @return string
      */
@@ -23,8 +23,8 @@ class FunctionReflection
 
         $lastLine = ($functionReflection->getEndLine() - 1);
 
-        for ($codeline = $functionReflection->getStartLine(); $codeline < $lastLine; $codeline++) {
-            $functionStringValue .= $file[$codeline];
+        for ($codeLine = $functionReflection->getStartLine(); $codeLine < $lastLine; $codeLine++) {
+            $functionStringValue .= $file[$codeLine];
         }
 
         return $functionStringValue;


### PR DESCRIPTION
# Changed log
- Add `php-7.2` version requirement to be under `required-dev` block in `composer.json` file.
- Fixing typos are about the comment annotation names and variable name.